### PR TITLE
Snecko Eye now tracks total number of additional cards drawn

### DIFF
--- a/src/main/java/relicstats/patches/StartTurnPatch.java
+++ b/src/main/java/relicstats/patches/StartTurnPatch.java
@@ -4,6 +4,7 @@ import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
 import com.megacrit.cardcrawl.actions.common.EnableEndTurnButtonAction;
 import relicstats.RelicStats;
+import relicstats.patches.relics.SneckoInfo;
 
 @SpirePatch(
         clz = EnableEndTurnButtonAction.class,
@@ -14,6 +15,7 @@ public class StartTurnPatch {
     @SpirePostfixPatch
     public static void patch(EnableEndTurnButtonAction _instance) {
         RelicStats.turnCount += 1;
+        SneckoInfo.onTurnStart();
     }
 
 }

--- a/src/main/java/relicstats/patches/relics/SneckoInfo.java
+++ b/src/main/java/relicstats/patches/relics/SneckoInfo.java
@@ -27,7 +27,8 @@ import java.util.Map;
 )
 public class SneckoInfo extends StatsInfo {
 
-    private static int[] costs = new int[5];
+    private static final int STAT_LENGTH = 6;
+    private static int[] stats = new int[STAT_LENGTH];
     private static String statId = getLocId(SneckoEye.ID);
     private static String[] description = CardCrawlGame.languagePack.getUIString(statId).TEXT;
     private static Map<AbstractCard, Integer> cards;
@@ -39,36 +40,38 @@ public class SneckoInfo extends StatsInfo {
         int total_cards = 0;
         for(int i = 0; i < 4; i++) {
             toDisplay.append(description[i]);
-            toDisplay.append(costs[i]);
-            total_cards += costs[i];
+            toDisplay.append(stats[i]);
+            total_cards += stats[i];
         }
         toDisplay.append(description[4]);
         if (total_cards == 0) {
             total_cards = 1;
         }
-        toDisplay.append(new DecimalFormat("#.###").format((float) (costs[4]) / total_cards));
+        toDisplay.append(new DecimalFormat("#.###").format((float) (stats[4]) / total_cards));
+        toDisplay.append(description[5]);
+        toDisplay.append(stats[5]);
         return toDisplay.toString();
     }
 
     public void resetStats() {
-        costs = new int[5];
+        stats = new int[STAT_LENGTH];
     }
 
     @Override
     public JsonElement onSaveRaw() {
         Gson gson = new Gson();
-        return gson.toJsonTree(costs);
+        return gson.toJsonTree(stats);
     }
 
     @Override
     public void onLoadRaw(JsonElement jsonElement) {
         if (jsonElement != null) {
             JsonArray array = jsonElement.getAsJsonArray();
-            for (int i = 0; i < 5; i++) {
+            for (int i = 0; i < STAT_LENGTH; i++) {
                 if (i >= array.size()) {
-                    costs[i] = 0;
+                    stats[i] = 0;
                 } else {
-                    costs[i] = array.get(i).getAsInt();
+                    stats[i] = array.get(i).getAsInt();
                 }
             }
         } else {
@@ -83,18 +86,24 @@ public class SneckoInfo extends StatsInfo {
     public static void patch(ConfusionPower _instance, AbstractCard c, int newCost) {
         if (AbstractDungeon.player.hasRelic(SneckoEye.ID) && newCost >= 0 && newCost <= 3) {
             if (c.type != AbstractCard.CardType.SKILL || !AbstractDungeon.player.hasPower(CorruptionPower.POWER_ID)) {
-                costs[newCost] += 1;
+                stats[newCost] += 1;
                 if (!cards.containsKey(c)) {
                     cards.put(c, c.cost);
                 }
                 // Record the difference between the original cost of the card (when first drawn) and the new cost
-                costs[4] += (cards.get(c) - newCost);
+                stats[4] += (cards.get(c) - newCost);
             }
         }
     }
 
     public static void onBattleStart() {
         cards = new HashMap<>();
+    }
+
+    public static void onTurnStart() {
+        if (AbstractDungeon.player.hasRelic(SneckoEye.ID)){
+            stats[5] += SneckoEye.HAND_MODIFICATION;
+        }
     }
 
     private static class Locator extends SpireInsertLocator {

--- a/src/main/resources/localization/eng/descriptions.json
+++ b/src/main/resources/localization/eng/descriptions.json
@@ -30,7 +30,8 @@
       " NL 1 energy: ",
       " NL 2 energy: ",
       " NL 3 energy: ",
-      " NL Average discount: "
+      " NL Average discount: ",
+      " NL Extra cards drawn: "
     ]
   },
   "STATS:CeramicFish": {

--- a/src/main/resources/localization/fra/descriptions.json
+++ b/src/main/resources/localization/fra/descriptions.json
@@ -30,7 +30,8 @@
       " NL 1 énergie: ",
       " NL 2 énergies: ",
       " NL 3 énergies: ",
-      " NL Réduction moyenne: "
+      " NL Réduction moyenne: ",
+      " NL Cartes supplémentaires: "
     ]
   },
   "STATS:CeramicFish": {


### PR DESCRIPTION
Someone suggested this on Merl's stream so I figured it would be an interesting addition.

I was worried about interaction with additional card draw, such as Bag of Prep/Ring of the Serpent/Doppel, but it appears SneckoEye modifies `AbstractPlayer.masterHandSize`, which resolves before actions, so we can just add `HAND_MODIFICATION` to the additional Snecko draws at the start of each turn.

First time doing anything StS related modding wise, so let me know if there's anything I need to change.